### PR TITLE
Change lines method

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,15 @@ If omitted, the default is `*l` (read one line without the newline).
 
 ## iter = reader:lines()
 
-returns an iterator that reads a line from the reader.
+returns an iterator that reads a line from the reader. this function repeatedly calls `reader:read('*l')` until the end of the file is reached.
+
+**NOTE**
+
+- When the end of the file is reached, if there is remaining data in the internal buffer, it will be returned as the last line.
+- If an error occurs during reading, it raises an error.
+- If timeout occurs during reading, it returns `nil`.
+
+this iterator cannot handle errors and timeouts during reading. so it is typically used for reading the text files.
 
 **Returns**
 

--- a/reader.lua
+++ b/reader.lua
@@ -245,10 +245,9 @@ end
 --- @return function
 function Reader:lines()
     return function()
-        local line = self:read('*l')
-        if not line and self.buf ~= '' then
-            line = self.buf
-            self.buf = ''
+        local line, err = self:readline()
+        if err then
+            error(err)
         end
         return line
     end

--- a/test/reader_test.lua
+++ b/test/reader_test.lua
@@ -221,6 +221,40 @@ function testcase.lines()
     assert.equal(lines, {})
 end
 
+function testcase.lines_error_handling()
+    local f = assert(io.tmpfile())
+    local r = assert(reader.new(f))
+    f:write('test line\n')
+    f:seek('set')
+
+    -- test that lines() throws error when reader is closed
+    r:close()
+    local iter = r:lines()
+    local err = assert.throws(iter)
+    assert.match(err, 'EBADF')
+end
+
+function testcase.lines_iteration_error()
+    local f = assert(io.tmpfile())
+    local r = assert(reader.new(f))
+    f:write('first line\n')
+    f:seek('set')
+
+    -- test that lines() throws error during iteration when reader becomes closed
+    local iter = r:lines()
+
+    -- Read first line successfully
+    local line = iter()
+    assert.equal(line, 'first line')
+
+    -- Close reader before next iteration
+    r:close()
+
+    -- Next iteration should throw an error
+    local err = assert.throws(iter)
+    assert.match(err, 'EBADF')
+end
+
 function testcase.close()
     local f = assert(io.tmpfile())
     local r = assert(reader.new(f))


### PR DESCRIPTION
This pull request improves the behavior and documentation of the `lines` iterator in the `Reader` class, clarifies its error handling, and adds comprehensive tests to ensure robust error reporting when the reader is closed. The main focus is on making the iterator's behavior more predictable and well-documented, especially in error scenarios.

**Enhancements to `Reader:lines` error handling:**

* Modified the `Reader:lines` method in `reader.lua` to raise an error if an error occurs during line reading, instead of silently returning or handling errors internally.
* Updated the documentation in `README.md` to clarify how the `lines` iterator behaves at EOF, on errors, and on timeouts, and to note that the iterator does not handle errors or timeouts during reading.

**Test improvements:**

* Added tests in `test/reader_test.lua` to verify that `lines()` raises an error when the reader is closed before or during iteration, ensuring correct error propagation and robustness.