### PR TITLE
Add size method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ print(dump({
 ```
 
 
+## n = reader:size()
+
+get the size of internal buffer.
+
+**Returns**
+
+- `n:integer`: size of internal buffer in bytes.
+
+
 ## fd = reader:getfd()
 
 get the file descriptor of the reader. if the reader is closed, returns negative value.

--- a/reader.lua
+++ b/reader.lua
@@ -52,6 +52,12 @@ function Reader:init(fd, f, sec)
     return self
 end
 
+--- size
+--- @return integer size
+function Reader:size()
+    return #self.buf
+end
+
 --- getfd
 --- @return integer fd
 function Reader:getfd()

--- a/test/reader_test.lua
+++ b/test/reader_test.lua
@@ -472,3 +472,31 @@ function testcase.readn_after_wait_success()
     pr:close()
 end
 
+function testcase.size()
+    local f = assert(io.tmpfile())
+    local r = assert(reader.new(f))
+
+    -- test that size returns 0 for empty buffer
+    assert.equal(r:size(), 0)
+
+    -- Write data with multiple lines to test readline buffering
+    local content = 'line1\nline2\nline3'
+    f:write(content)
+    f:seek('set')
+
+    -- Read first line - this will read "line1\n" and leave remaining in buffer
+    local line = r:readline(true)
+    assert.equal(line, 'line1\n')
+    content = content:sub(#line + 1)
+
+    -- Buffer should contain the remaining data
+    assert.equal(r:size(), #content)
+
+    -- Read all remaining to verify buffer contents and empty buffer
+    local data = r:readall()
+    -- Buffer should be empty after reading all
+    assert.equal(r:size(), 0)
+    -- Remaining data should contain "line2\nline3" and possibly the newline from the first line
+    assert.equal(#data, #content)
+end
+


### PR DESCRIPTION
This pull request adds a new method to the `Reader` class that allows users to check the size of the internal buffer, and includes corresponding documentation and tests. The main changes are grouped below:

New feature: Buffer size inspection

* Added a `size()` method to the `Reader` class in `reader.lua`, which returns the size of the internal buffer in bytes.
* Documented the new `size()` method in `README.md`, describing its purpose and return value.

Testing

* Added a test case in `test/reader_test.lua` to verify the behavior of the new `size()` method, checking the buffer size before and after reading operations.