### PR TITLE
Replace io.readn dependency with io.read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,12 @@ on:
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -27,6 +26,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
@@ -37,15 +38,15 @@ jobs:
           - "lj-v2.1:latest"
     steps:
     -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
+    -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: mah0x211/setup-lua@v1
-      with:
-        versions: ${{ matrix.lua-version }}
     -
       name: Install Tools
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         luarocks install assert
         luarocks install os-pipe
         luarocks install time-clock
+        luarocks install io-close
     -
       name: Install
       run: |

--- a/reader.lua
+++ b/reader.lua
@@ -26,7 +26,7 @@ local type = type
 local isfile = require('io.isfile')
 local fopen = require('io.fopen')
 local fileno = require('io.fileno')
-local readn = require('io.readn')
+local read = require('io.read')
 local wait_readable = require('gpoll').wait_readable
 -- constants
 local EINVAL = require('errno').EINVAL
@@ -84,22 +84,29 @@ function Reader:close()
     return true
 end
 
---- read
+--- do_read
 --- @param fd integer
---- @param count integer
+--- @param count integer?
 --- @param sec number?
 --- @return string? data
 --- @return any err
 --- @return boolean? timeout
-local function read(fd, count, sec)
-    local data, err, again = readn(fd, count)
-    if again then
-        fd, err, again = wait_readable(fd, sec)
-        if not fd then
-            return nil, err, again
-        end
-        return readn(fd, count)
+local function do_read(fd, count, sec)
+    local data, err, again = read(fd, count)
+    if data or not again then
+        -- success, EOF, hard error or partial data with again=true.
+        -- callers loop until they have enough; the again flag is intentionally
+        -- dropped because partial data already advanced the fd position and
+        -- must be consumed before any further wait_readable/read attempt.
+        return data, err
     end
+
+    -- no data and EAGAIN/EWOULDBLOCK/EINTR: wait then retry once
+    local ok, werr, wtimeout = wait_readable(fd, sec)
+    if not ok then
+        return nil, werr, wtimeout
+    end
+    data, err = read(fd, count)
     return data, err
 end
 
@@ -124,20 +131,18 @@ function Reader:readn(n)
     local buf = self.buf
     local len = #buf
     if len < n then
-        local data, err, timeout = read(self.fd, n - len, self.waitsec)
+        local data, err, timeout = do_read(self.fd, n - len, self.waitsec)
         if not data then
             if err == nil and timeout == nil and len > 0 then
-                -- return the remaining buffer
+                -- EOF with buffered bytes: return what we have
                 self.buf = ''
                 return buf
             end
             return nil, err, timeout
         end
-        -- append data to the buffer
         buf = buf .. data
     end
 
-    -- return the specified bytes from the buffer
     self.buf = sub(buf, n + 1)
     return sub(buf, 1, n)
 end
@@ -155,7 +160,7 @@ function Reader:readall()
     self.buf = ''
 
     -- read all data from the file
-    local data, err, timeout = read(self.fd, nil, self.waitsec)
+    local data, err, timeout = do_read(self.fd, nil, self.waitsec)
     if err then
         return nil, err
     elseif data then
@@ -183,17 +188,18 @@ function Reader:readline(with_newline)
     local head, tail = find(buf, '\r?\n', 1)
     while not head do
         -- need to read more data
-        local data, err, timeout = read(self.fd, nil, self.waitsec)
+        local data, err, timeout = do_read(self.fd, nil, self.waitsec)
         if not data then
             if err == nil and timeout == nil and #buf > 0 then
-                -- return the remaining buffer
+                -- EOF: return the remaining buffer as the last line
                 self.buf = ''
                 return buf
             end
+            -- timeout or hard error: preserve buffered bytes for a later retry
+            self.buf = buf
             return nil, err, timeout
         end
         buf = buf .. data
-        self.buf = buf
 
         -- find the newline again
         head, tail = find(buf, '\r?\n', 1)

--- a/rockspecs/io-reader-dev-1.rockspec
+++ b/rockspecs/io-reader-dev-1.rockspec
@@ -16,7 +16,7 @@ dependencies = {
     "io-isfile >= 0.1.0",
     "io-fopen >= 0.1.3",
     "io-fileno >= 0.1.0",
-    "io-readn >= 0.1.0",
+    "io-read >= 0.3.0",
     "metamodule >= 0.5.0",
 }
 build = {

--- a/test/reader_test.lua
+++ b/test/reader_test.lua
@@ -1,7 +1,10 @@
 require('luacov')
 local testcase = require('testcase')
+local fork = require('testcase.fork')
+local sleep = require('testcase.timer').sleep
 local assert = require('assert')
 local fileno = require('io.fileno')
+local io_close = require('io.close')
 local reader = require('io.reader')
 local pipe = require('os.pipe')
 local gettime = require('time.clock').gettime
@@ -469,6 +472,147 @@ function testcase.readn_after_wait_success()
     assert.is_nil(err)
     assert.is_nil(timeout)
 
+    pr:close()
+end
+
+-- Regression: io.read may return (data, nil, true) on EAGAIN with partial
+-- bytes already accumulated. readn must not drop those bytes; on timeout it
+-- should keep them in the internal buffer for a subsequent read.
+function testcase.readn_partial_with_pending_writer()
+    local pr, pw, perr = pipe(true)
+    assert(perr == nil, perr)
+
+    local r = assert(reader.new(pr:fd(), 0.1))
+    pw:write('hello')
+
+    -- writer is still open; only 5 bytes available but we ask for 10.
+    -- io.read returns partial data + again=true; do_read returns the partial
+    -- bytes immediately (no again flag), so readn returns them as-is.
+    local data, err, timeout = r:readn(10)
+    assert.equal(data, 'hello')
+    assert.is_nil(err)
+    assert.is_nil(timeout)
+
+    -- next readn gets the remaining bytes
+    pw:write('world')
+    pw:close()
+    data, err, timeout = r:readn(5)
+    assert.equal(data, 'world')
+    assert.is_nil(err)
+    assert.is_nil(timeout)
+
+    pr:close()
+end
+
+-- Regression: readall on a non-blocking pipe must surface partial bytes that
+-- io.read returned together with again=true, instead of discarding them when
+-- the subsequent wait_readable times out.
+function testcase.readall_partial_with_pending_writer()
+    local pr, pw, perr = pipe(true)
+    assert(perr == nil, perr)
+
+    local r = assert(reader.new(pr:fd(), 0.1))
+    pw:write('hello')
+
+    -- writer is still open; readall reads what is available, waits, times out
+    -- and must return the bytes already read instead of dropping them.
+    local data, err = r:readall()
+    assert.equal(data, 'hello')
+    assert.is_nil(err)
+
+    pr:close()
+    pw:close()
+end
+
+-- Regression: readline must keep partial bytes buffered when the line has not
+-- terminated yet and the underlying read times out.
+function testcase.readline_partial_with_pending_writer()
+    local pr, pw, perr = pipe(true)
+    assert(perr == nil, perr)
+
+    local r = assert(reader.new(pr:fd(), 0.1))
+    pw:write('partial')
+
+    local data, err, timeout = r:readline()
+    assert.is_nil(data)
+    assert.is_nil(err)
+    assert.is_true(timeout)
+    assert.equal(r:size(), 7)
+
+    -- after the writer completes the line, the buffered prefix must be reused
+    pw:write(' line\n')
+    pw:close()
+    data, err, timeout = r:readline()
+    assert.equal(data, 'partial line')
+    assert.is_nil(err)
+    assert.is_nil(timeout)
+
+    pr:close()
+end
+
+function testcase.readn_eof_with_buffered_data()
+    local f = assert(io.tmpfile())
+    local r = assert(reader.new(f))
+    f:write('hello\nworld')
+    f:seek('set')
+
+    -- readline reads 'hello\nworld' from fd, returns 'hello', buffers 'world'
+    -- fd is now at EOF
+    local line = r:readline()
+    assert.equal(line, 'hello')
+
+    -- readn: buf='world', n=100; do_read returns EOF (nil,nil,nil)
+    -- with len=5>0, err=nil, timeout=nil -> returns buffered 'world'
+    local data, err = r:readn(100)
+    assert.equal(data, 'world')
+    assert.is_nil(err)
+
+    f:close()
+end
+
+function testcase.readall_error_on_bad_fd()
+    local f = assert(io.tmpfile())
+    f:write('hello')
+    f:seek('set')
+    local r = assert(reader.new(f))
+
+    -- close the reader's internal fd out-of-band so do_read gets EBADF
+    assert(io_close(r:getfd()))
+
+    -- readall should propagate the error
+    local data, err = r:readall()
+    assert.is_nil(data)
+    assert.match(err, 'EBADF')
+
+    f:close()
+end
+
+function testcase.do_read_success_after_wait_readable()
+    local pr, pw, perr = pipe(true)
+    assert(perr == nil, perr)
+
+    local r = assert(reader.new(pr:fd(), 2.0))
+
+    -- child writes data after a short delay so parent's first io.read hits EAGAIN
+    local p = assert(fork())
+    if p:is_child() then
+        sleep(0.05)
+        assert(pw:write('hello world'))
+        assert(pw:close())
+        assert(pr:close())
+        return
+    end
+
+    -- parent: close write end so EOF is signaled after child writes
+    pw:close()
+    -- do_read will hit EAGAIN on first read, wait_readable succeeds, retry read succeeds
+    local data, err, timeout = r:readn(11)
+    assert.equal(data, 'hello world')
+    assert.is_nil(err)
+    assert.is_nil(timeout)
+
+    local res = assert(p:wait())
+    assert.equal(res.exit, 0)
     pr:close()
 end
 


### PR DESCRIPTION
This pull request refactors the `io.reader` module to use the new `io.read` API instead of `io.readn`, and updates the logic to correctly handle partial reads, timeouts, and buffering. It also expands the test suite with regression tests for edge cases involving partial reads and timeouts. Additionally, the CI workflow is updated to use a containerized Lua environment and the new dependencies.

**Core refactor and bug fixes:**

* Refactored `reader.lua` to use `io.read` (from `io.readn`), introducing a new `do_read` helper to properly handle partial reads, EAGAIN/EINTR, and buffering. This ensures that partial data is never dropped and is correctly returned or buffered for subsequent reads. [[1]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L29-R29) [[2]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L87-R109) [[3]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L127-L140) [[4]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L158-R163) [[5]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L186-L196)
* Updated dependency from `io-readn` to `io-read >= 0.3.0` in the rockspec.

**Testing improvements:**

* Added comprehensive regression tests to `reader_test.lua` for scenarios involving partial reads, timeouts, EOF handling, and error propagation. These tests ensure correct behavior when the underlying file descriptor returns partial data or errors, and verify that the internal buffer is managed properly. [[1]](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286R478-R618) [[2]](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286R3-R7)

**CI and workflow updates:**

* Modified `.github/workflows/test.yml` to use the `ghcr.io/mah0x211/lua-ci:latest` container for both `luacheck` and `test` jobs, removing the old Lua setup action. Added `io-close` to the installed tools. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R13-L19) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R29-R30) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R40-L48) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R58)

**Summary of most important changes:**

**Reader implementation and API changes:**
- Replaced use of `io.readn` with `io.read`, and introduced a new `do_read` function to handle partial reads, EAGAIN/EINTR, and correct buffering, preventing loss of partial data and ensuring robust timeout handling. [[1]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L29-R29) [[2]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L87-R109) [[3]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L127-L140) [[4]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L158-R163) [[5]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L186-L196)
- Updated rockspec dependency from `io-readn` to `io-read >= 0.3.0`.

**Testing and regression coverage:**
- Added extensive regression tests for partial reads, timeouts, EOF, and error cases to ensure correct buffer management and error propagation in `reader_test.lua`. [[1]](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286R478-R618) [[2]](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286R3-R7)

**CI workflow improvements:**
- Switched CI jobs to run in a containerized Lua environment and updated tool installation to include `io-close`, streamlining the workflow and ensuring consistent test environments. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R13-L19) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R29-R30) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R40-L48) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R58)