### PR TITLE
Several bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ read `n` bytes from the reader.
 
 **Returns**
 
-- `s:string`: read data.
+- `s:string`: read data. if `timeout` is `true`, `s` may contain fewer than `n` bytes (partial data received before the timeout).
 - `err:any`: error message.
 - `timeout:boolean`: `true` if timed out.
 

--- a/reader.lua
+++ b/reader.lua
@@ -104,29 +104,48 @@ end
 --- @return any err
 --- @return boolean? timeout
 local function do_read(fd, count, deadline)
-    local data, err, again = read(fd, count)
-    if data or not again then
-        -- success, EOF, hard error or partial data with again=true.
-        -- callers loop until they have enough; the again flag is intentionally
-        -- dropped because partial data already advanced the fd position and
-        -- must be consumed before any further wait_readable/read attempt.
-        return data, err
-    end
+    local timeout = deadline and deadline:is_done()
+    local remain = count
+    local data
+    while not timeout do
+        local chunk, err, again = read(fd, remain)
+        if err then
+            return data, err
+        elseif chunk then
+            if not remain then
+                -- read once if count is not specified
+                return chunk
+            end
 
-    -- no data and EAGAIN/EWOULDBLOCK/EINTR: check remaining budget then wait
-    local sec
-    if deadline then
-        sec = deadline:remain()
-        if sec <= 0 then
-            return nil, nil, true
+            -- append chunk to the data
+            data = (data or '') .. chunk
+            if not again then
+                -- read enough data
+                return data
+            end
+            -- update remaining bytes to read
+            remain = remain - #chunk
+        elseif not again then
+            -- EOF: return what we have
+            return data
+        end
+
+        -- no data and EAGAIN/EWOULDBLOCK/EINTR: check remaining budget then wait
+        local sec = deadline and deadline:remain() or nil
+        if sec and sec <= 0 then
+            -- timeout: return what we have
+            return data, nil, true
+        end
+
+        -- wait until the file is readable or timeout
+        local ok
+        ok, err, timeout = wait_readable(fd, sec)
+        if not ok then
+            return data, err, timeout
         end
     end
-    local ok, werr, wtimeout = wait_readable(fd, sec)
-    if not ok then
-        return nil, werr, wtimeout
-    end
-    data, err = read(fd, count)
-    return data, err
+
+    return data, nil, true
 end
 
 --- readn
@@ -150,8 +169,10 @@ function Reader:readn(n)
     local deadline = self.waitsec and new_deadline(self.waitsec)
     local buf = self.buf
     local len = #buf
+    local timeout
     if len < n then
-        local data, err, timeout = do_read(self.fd, n - len, deadline)
+        local data, err
+        data, err, timeout = do_read(self.fd, n - len, deadline)
         if not data then
             if err == nil and timeout == nil and len > 0 then
                 -- EOF with buffered bytes: return what we have
@@ -164,7 +185,7 @@ function Reader:readn(n)
     end
 
     self.buf = sub(buf, n + 1)
-    return sub(buf, 1, n)
+    return sub(buf, 1, n), nil, timeout
 end
 
 --- readall

--- a/rockspecs/io-reader-dev-1.rockspec
+++ b/rockspecs/io-reader-dev-1.rockspec
@@ -18,6 +18,7 @@ dependencies = {
     "io-fileno >= 0.1.0",
     "io-read >= 0.3.0",
     "metamodule >= 0.5.0",
+    "time-clock >= 0.5.0",
 }
 build = {
     type = "builtin",

--- a/test/reader_test.lua
+++ b/test/reader_test.lua
@@ -491,7 +491,7 @@ function testcase.readn_partial_with_pending_writer()
     local data, err, timeout = r:readn(10)
     assert.equal(data, 'hello')
     assert.is_nil(err)
-    assert.is_nil(timeout)
+    assert.is_true(timeout)
 
     -- next readn gets the remaining bytes
     pw:write('world')
@@ -548,6 +548,21 @@ function testcase.readline_partial_with_pending_writer()
     assert.is_nil(timeout)
 
     pr:close()
+end
+
+-- sec=0 creates a deadline that is immediately done (new_deadline(0) sets
+-- d->done=true), so do_read's while loop is never entered and the post-loop
+-- `return data, nil, true` fires on the very first call.
+function testcase.readn_timeout_when_deadline_already_expired()
+    local pr, pw, perr = pipe(true)
+    assert(perr == nil, perr)
+    local r = assert(reader.new(pr:fd(), 0))
+    local data, err, timeout = r:readn(1)
+    assert.is_nil(data)
+    assert.is_nil(err)
+    assert.is_true(timeout)
+    pr:close()
+    pw:close()
 end
 
 function testcase.readn_eof_with_buffered_data()


### PR DESCRIPTION
This pull request improves the handling of timeouts and partial reads in the `Reader:readn` method and its underlying logic. Now, when a timeout occurs during a read operation, the function can return partial data along with a timeout indicator, allowing callers to handle incomplete reads more robustly. Documentation and tests are updated to reflect this behavior.

**Timeout and partial read handling:**

* Enhanced the `do_read` function in `reader.lua` to loop and accumulate data until the requested number of bytes is read, an error occurs, or a timeout is reached. If a timeout occurs, it returns any partial data read, an error (if any), and a `timeout` flag. (`reader.lua`, [reader.luaL107-R148](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L107-R148))
* Updated the `Reader:readn` method to propagate the `timeout` flag and partial data returned by `do_read`, allowing callers to distinguish between full, partial, and timed-out reads. (`reader.lua`, [[1]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3R172-R175) [[2]](diffhunk://#diff-d4136ee026399b3010888e7f70851c8717cb30b776f2ea1e05240a73e0e0b3b3L167-R188)

**Documentation and dependency updates:**

* Clarified in the `README.md` that when a timeout occurs, the returned string may contain fewer than `n` bytes. (`README.md`, [README.mdL119-R119](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R119))
* Added `time-clock >= 0.5.0` as a dependency in the rockspec to support deadline handling. (`rockspecs/io-reader-dev-1.rockspec`, [rockspecs/io-reader-dev-1.rockspecR21](diffhunk://#diff-e28d9e09a09ecd5741f9a8c1827dfd77e7ce770f6f9c8404f83090d4b9191edaR21))

**Testing improvements:**

* Adjusted the test for partial reads to assert that the `timeout` flag is `true` when a partial read occurs due to a timeout. (`test/reader_test.lua`, [test/reader_test.luaL494-R494](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286L494-R494))